### PR TITLE
feat: adapt manifest to work with Safe App

### DIFF
--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -14,6 +14,36 @@ const nextConfig = {
     config.externals.push("pino-pretty", "lokijs", "encoding");
     return config;
   },
+  // Safe App setup
+  headers: manifestHeaders,
 };
 
 module.exports = nextConfig;
+
+/**
+ * Add specific CORS headers to the manifest.json file
+ * This is required to allow the Safe Browser to fetch the manifest file
+ * More info: https://help.safe.global/en/articles/40859-add-a-custom-safe-app
+ */
+async function manifestHeaders() {
+  const corsHeaders = [
+    {
+      key: "Access-Control-Allow-Origin",
+      value: "*",
+    },
+    {
+      key: "Access-Control-Allow-Methods",
+      value: "GET",
+    },
+    {
+      key: "Access-Control-Allow-Headers",
+      value: "X-Requested-With, content-type, Authorization",
+    },
+  ];
+  return [
+    {
+      source: "/manifest.json",
+      headers: corsHeaders,
+    },
+  ];
+}

--- a/packages/nextjs/public/manifest.json
+++ b/packages/nextjs/public/manifest.json
@@ -1,5 +1,15 @@
 {
-  "name": "Scaffold-ETH 2 DApp",
-  "description": "A DApp built with Scaffold-ETH",
-  "iconPath": "logo.svg"
+  "short_name": "Balancer pool creator",
+  "name": "Balancer pool creator",
+  "description": "Create and initialize a variety of liquidity pool types with Balancer protocol",
+  "icons": [
+    {
+      "src": "/logo.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ],
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#ffffff"
 }


### PR DESCRIPTION
Adds `nextjs headers` and required `manifest.json` fields to be able to run as a `Safe App`.

Logo should be updated as it is using the original logo in the scaffolding repo. 