### PR TITLE
Add support for avalanche

### DIFF
--- a/packages/nextjs/app/v3/_components/ChooseParameters/AmplificationParameter.tsx
+++ b/packages/nextjs/app/v3/_components/ChooseParameters/AmplificationParameter.tsx
@@ -1,5 +1,6 @@
 import { NumberParameterButton } from "./NumberParameterButton";
 import { type HandleNumberInputChange } from "./types";
+import { STABLE_POOL_CONSTRAINTS } from "@balancer/sdk";
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
 import { NumberInput } from "~~/components/common";
 import { usePoolCreationStore } from "~~/hooks/v3";
@@ -9,9 +10,11 @@ export function AmplificationParameter({
 }: {
   handleNumberInputChange: HandleNumberInputChange;
 }) {
-  const amplificationParameters = ["10", "100", "1000"];
-
   const { amplificationParameter, updatePool } = usePoolCreationStore();
+
+  const ampOptions = ["100", "1000", "10000"];
+  const minAmp = Number(STABLE_POOL_CONSTRAINTS.MIN_AMP);
+  const maxAmp = Number(STABLE_POOL_CONSTRAINTS.MAX_AMP);
 
   return (
     <div className="bg-base-100 p-5 rounded-xl">
@@ -28,7 +31,7 @@ export function AmplificationParameter({
       </div>
 
       <div className="flex gap-2 items-end">
-        {amplificationParameters.map(value => (
+        {ampOptions.map(value => (
           <NumberParameterButton
             key={value}
             value={value}
@@ -39,11 +42,9 @@ export function AmplificationParameter({
         ))}
         <div className="w-[135px]">
           <NumberInput
-            placeholder="1 - 5000"
+            placeholder={`${minAmp} - ${maxAmp}`}
             value={amplificationParameter}
-            onChange={e => handleNumberInputChange(e, "amplificationParameter", 0, 5000)}
-            min={1}
-            max={5000}
+            onChange={e => handleNumberInputChange(e, "amplificationParameter", minAmp, maxAmp)}
             step={1}
           />
         </div>

--- a/packages/nextjs/app/v3/_components/ChooseToken/ChooseToken.tsx
+++ b/packages/nextjs/app/v3/_components/ChooseToken/ChooseToken.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { BoostOpportunityModal, RateProviderModal } from "./";
-import { PoolType, TokenType, erc20Abi } from "@balancer/sdk";
-import { zeroAddress } from "viem";
+import { PoolType, TokenType } from "@balancer/sdk";
+import { erc20Abi, zeroAddress } from "viem";
 import { useAccount, useReadContract } from "wagmi";
 import { Cog6ToothIcon, LockClosedIcon, LockOpenIcon, TrashIcon } from "@heroicons/react/24/outline";
 import { Alert, Checkbox, TextField, TokenField } from "~~/components/common";

--- a/packages/nextjs/app/v3/_components/ChooseType.tsx
+++ b/packages/nextjs/app/v3/_components/ChooseType.tsx
@@ -1,14 +1,11 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { PoolType } from "@balancer/sdk";
-import { avalanche } from "viem/chains";
 import { ArrowUpRightIcon } from "@heroicons/react/24/solid";
-import { useTargetNetwork } from "~~/hooks/scaffold-eth";
 import { usePoolCreationStore } from "~~/hooks/v3";
 import { AllowedPoolTypes } from "~~/hooks/v3/usePoolCreationStore";
 
 export function ChooseType() {
   const { poolType, updatePool, tokenConfigs } = usePoolCreationStore();
-  const { targetNetwork } = useTargetNetwork();
 
   const POOL_TYPES: Record<AllowedPoolTypes, { label: string; description: string }> = {
     [PoolType.Weighted]: {
@@ -26,29 +23,22 @@ export function ChooseType() {
       description:
         "Gyro's elliptic concentrated liquidity pools concentrate liquidity within price bounds with the flexibility to asymmetrically focus liquidity",
     },
-  } as Record<AllowedPoolTypes, { label: string; description: string }>;
-
-  // Stable surge not available on avalanche for now
-  if (targetNetwork.id !== avalanche.id) {
-    POOL_TYPES[PoolType.StableSurge] = {
+    [PoolType.StableSurge]: {
       label: "Stable Surge",
       description:
         "A Balancer core stable pool that uses a stable surge hook deployed by the official stable surge factory",
-    };
-  }
-  useEffect(() => {
-    if (targetNetwork.id === avalanche.id && poolType === PoolType.StableSurge) updatePool({ poolType: undefined });
-  }, [targetNetwork.id, poolType, updatePool]);
-
-  const availablePoolTypes = Object.keys(POOL_TYPES);
+    },
+  };
 
   return (
     <>
       <div className="flex flex-col justify-center h-full gap-10 px-7 py-5">
         <div
-          className={`grid ${availablePoolTypes.length % 3 === 0 ? "grid-cols-3" : "grid-cols-2"} gap-5 justify-around`}
+          className={`grid ${
+            Object.keys(POOL_TYPES).length % 3 === 0 ? "grid-cols-3" : "grid-cols-2"
+          } gap-5 justify-around`}
         >
-          {availablePoolTypes.map(type => (
+          {Object.keys(POOL_TYPES).map(type => (
             <button
               key={type}
               className={`${

--- a/packages/nextjs/app/v3/_components/ChooseType.tsx
+++ b/packages/nextjs/app/v3/_components/ChooseType.tsx
@@ -1,60 +1,71 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { PoolType } from "@balancer/sdk";
+import { avalanche } from "viem/chains";
 import { ArrowUpRightIcon } from "@heroicons/react/24/solid";
+import { useTargetNetwork } from "~~/hooks/scaffold-eth";
 import { usePoolCreationStore } from "~~/hooks/v3";
 import { AllowedPoolTypes } from "~~/hooks/v3/usePoolCreationStore";
 
-const POOL_TYPES: AllowedPoolTypes[] = [PoolType.Weighted, PoolType.Stable, PoolType.StableSurge, PoolType.GyroE];
-
-const POOL_TYPE_INFO: Record<AllowedPoolTypes, { label: string; description: string }> = {
-  [PoolType.Weighted]: {
-    label: "Weighted",
-    description:
-      "Highly configurable and versatile, Weighted Pools support up to 8 tokens with customizable weightings, allowing for fine-tuned exposure to multiple assets",
-  },
-  [PoolType.Stable]: {
-    label: "Stable",
-    description:
-      "Engineered for assets that trade near parity, Stable Pools are perfect for tightly correlated assets like Stablecoins, ensuring seamless trading with minimal slippage",
-  },
-  [PoolType.StableSurge]: {
-    label: "Stable Surge",
-    description:
-      "A Balancer core stable pool that uses a stable surge hook deployed by the official stable surge factory",
-  },
-  [PoolType.GyroE]: {
-    label: "Gyro E-CLP",
-    description:
-      "Gyro's elliptic concentrated liquidity pools concentrate liquidity within price bounds with the flexibility to asymmetrically focus liquidity",
-  },
-};
-
 export function ChooseType() {
   const { poolType, updatePool, tokenConfigs } = usePoolCreationStore();
+  const { targetNetwork } = useTargetNetwork();
+
+  const POOL_TYPES: Record<AllowedPoolTypes, { label: string; description: string }> = {
+    [PoolType.Weighted]: {
+      label: "Weighted",
+      description:
+        "Highly configurable and versatile, Weighted Pools support up to 8 tokens with customizable weightings, allowing for fine-tuned exposure to multiple assets",
+    },
+    [PoolType.Stable]: {
+      label: "Stable",
+      description:
+        "Engineered for assets that trade near parity, Stable Pools are perfect for tightly correlated assets like Stablecoins, ensuring seamless trading with minimal slippage",
+    },
+    [PoolType.GyroE]: {
+      label: "Gyro E-CLP",
+      description:
+        "Gyro's elliptic concentrated liquidity pools concentrate liquidity within price bounds with the flexibility to asymmetrically focus liquidity",
+    },
+  } as Record<AllowedPoolTypes, { label: string; description: string }>;
+
+  // Stable surge not available on avalanche for now
+  if (targetNetwork.id !== avalanche.id) {
+    POOL_TYPES[PoolType.StableSurge] = {
+      label: "Stable Surge",
+      description:
+        "A Balancer core stable pool that uses a stable surge hook deployed by the official stable surge factory",
+    };
+  }
+  useEffect(() => {
+    if (targetNetwork.id === avalanche.id && poolType === PoolType.StableSurge) updatePool({ poolType: undefined });
+  }, [targetNetwork.id, poolType, updatePool]);
+
+  const availablePoolTypes = Object.keys(POOL_TYPES);
 
   return (
     <>
       <div className="flex flex-col justify-center h-full gap-10 px-7 py-5">
-        <div className="grid grid-cols-2 gap-5 justify-around">
-          {POOL_TYPES.map(type => (
+        <div
+          className={`grid ${availablePoolTypes.length % 3 === 0 ? "grid-cols-3" : "grid-cols-2"} gap-5 justify-around`}
+        >
+          {availablePoolTypes.map(type => (
             <button
               key={type}
               className={`${
                 type === poolType ? `${selectedPoolStyles}` : `bg-base-100 ${hoverPoolStyles} shadow-lg`
               } p-4 w-full rounded-xl `}
-              onClick={() => updatePool({ poolType: type, tokenConfigs: tokenConfigs.slice(0, 4) })}
+              onClick={() => updatePool({ poolType: type as AllowedPoolTypes, tokenConfigs: tokenConfigs.slice(0, 4) })}
             >
               <div className="flex flex-col text-center">
-                <div className="font-bold text-xl w-full">{POOL_TYPE_INFO[type].label}</div>
+                <div className="font-bold text-xl w-full">{POOL_TYPES[type as AllowedPoolTypes].label}</div>
               </div>
             </button>
           ))}
         </div>
 
         <div>
-          {/* <div className="text-xl mb-2 ml-2">{poolType ? "Description" : "Instructions"}</div> */}
           <div className="text-xl bg-base-100 rounded-xl p-5 border border-neutral h-32 flex flex-col justify-center">
-            {poolType ? POOL_TYPE_INFO[poolType].description : INITIAL_INSTRUCTIONS}
+            {poolType ? POOL_TYPES[poolType]?.description : INITIAL_INSTRUCTIONS}
           </div>
         </div>
       </div>

--- a/packages/nextjs/app/v3/page.tsx
+++ b/packages/nextjs/app/v3/page.tsx
@@ -44,11 +44,8 @@ const BalancerV3: NextPage = () => {
                 <div className="bg-base-200 w-full max-w-[400px] rounded-xl shadow-lg p-5 h-fit">
                   <div className="flex justify-between items-center gap-2 mb-3 mr-2">
                     <div className="font-bold text-2xl">Pool Preview</div>
-                    {chain && (
-                      <div
-                        className="text-xl font-bold"
-                        style={{ color: typeof chain.color === "string" ? chain.color : "rgb(135, 255, 101)" }}
-                      >
+                    {chain && typeof selectedNetwork.color === "string" && (
+                      <div className="text-xl font-bold" style={{ color: selectedNetwork.color }}>
                         {chain?.name}
                       </div>
                     )}

--- a/packages/nextjs/hooks/cow/useApproveTokenTxHash.ts
+++ b/packages/nextjs/hooks/cow/useApproveTokenTxHash.ts
@@ -1,7 +1,6 @@
-import { erc20Abi } from "@balancer/sdk";
 import { useSafeAppsSDK } from "@safe-global/safe-apps-react-sdk";
 import { useQuery } from "@tanstack/react-query";
-import { parseEventLogs, parseUnits } from "viem";
+import { erc20Abi, parseEventLogs, parseUnits } from "viem";
 import { usePublicClient } from "wagmi";
 import { usePoolCreationStore } from "~~/hooks/cow/usePoolCreationStore";
 import { useIsSafeWallet } from "~~/hooks/safe/useIsSafeWallet";

--- a/packages/nextjs/hooks/token/useAllowanceOnPermit2.ts
+++ b/packages/nextjs/hooks/token/useAllowanceOnPermit2.ts
@@ -1,4 +1,4 @@
-import { BALANCER_ROUTER, PERMIT2, permit2Abi } from "@balancer/sdk";
+import { PERMIT2, balancerV3Contracts, permit2Abi } from "@balancer/sdk";
 import { Address, zeroAddress } from "viem";
 import { useReadContract, useWalletClient } from "wagmi";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth";
@@ -14,6 +14,6 @@ export const useAllowanceOnPermit2 = (token: Address) => {
     address: PERMIT2[chainId],
     abi: permit2Abi,
     functionName: "allowance",
-    args: [connectedAddress, token, BALANCER_ROUTER[chainId]],
+    args: [connectedAddress, token, balancerV3Contracts.Router[chainId as keyof typeof balancerV3Contracts.Router]],
   });
 };

--- a/packages/nextjs/hooks/token/useApproveToken.ts
+++ b/packages/nextjs/hooks/token/useApproveToken.ts
@@ -1,6 +1,5 @@
-import { erc20Abi } from "@balancer/sdk";
 import { useMutation } from "@tanstack/react-query";
-import { Address } from "viem";
+import { Address, erc20Abi } from "viem";
 import { usePublicClient, useWalletClient } from "wagmi";
 import { useTransactor } from "~~/hooks/scaffold-eth";
 

--- a/packages/nextjs/hooks/token/useReadToken.ts
+++ b/packages/nextjs/hooks/token/useReadToken.ts
@@ -1,5 +1,4 @@
-import { erc20Abi } from "@balancer/sdk";
-import { Address, zeroAddress } from "viem";
+import { Address, erc20Abi, zeroAddress } from "viem";
 import { useReadContract, useWalletClient } from "wagmi";
 
 export const useReadToken = (token: Address | undefined, spender?: Address) => {

--- a/packages/nextjs/hooks/v3/useBoostableWhitelist.ts
+++ b/packages/nextjs/hooks/v3/useBoostableWhitelist.ts
@@ -22,6 +22,7 @@ export const useBoostableWhitelist = () => {
       const boostableWhitelist: BoostableWhitelist = await response.json();
 
       const boostableAddresses = boostableWhitelist
+        .filter(list => list.id === "boosted_aave")
         .map(list => list.addresses[targetNetwork.id] || [])
         .flat()
         .map(address => `"${address}"`)

--- a/packages/nextjs/hooks/v3/useCreatePool.ts
+++ b/packages/nextjs/hooks/v3/useCreatePool.ts
@@ -7,10 +7,10 @@ import {
   CreatePoolV3WeightedInput,
   PoolType,
   calcDerivedParams,
-  gyroECLPPoolFactoryAbi_V3,
-  stablePoolFactoryAbi_V3,
-  stableSurgeFactoryAbi,
-  weightedPoolFactoryAbi_V3,
+  gyroECLPPoolFactoryAbiExtended,
+  stablePoolFactoryAbiExtended,
+  stableSurgeFactoryAbiExtended,
+  weightedPoolFactoryAbiExtended_V3,
 } from "@balancer/sdk";
 import { useMutation } from "@tanstack/react-query";
 import { parseUnits, zeroAddress } from "viem";
@@ -19,10 +19,10 @@ import { useTransactor } from "~~/hooks/scaffold-eth";
 import { useBoostableWhitelist, usePoolCreationStore } from "~~/hooks/v3";
 
 export const poolFactoryAbi = {
-  [PoolType.Weighted]: weightedPoolFactoryAbi_V3,
-  [PoolType.Stable]: stablePoolFactoryAbi_V3,
-  [PoolType.StableSurge]: stableSurgeFactoryAbi,
-  [PoolType.GyroE]: gyroECLPPoolFactoryAbi_V3,
+  [PoolType.Weighted]: weightedPoolFactoryAbiExtended_V3,
+  [PoolType.Stable]: stablePoolFactoryAbiExtended,
+  [PoolType.StableSurge]: stableSurgeFactoryAbiExtended,
+  [PoolType.GyroE]: gyroECLPPoolFactoryAbiExtended,
 };
 
 const SWAP_FEE_PERCENTAGE_DECIMALS = 16;

--- a/packages/nextjs/hooks/v3/useMultiSwap.ts
+++ b/packages/nextjs/hooks/v3/useMultiSwap.ts
@@ -2,7 +2,7 @@ import {
   BALANCER_BATCH_ROUTER,
   MAX_UINT256,
   Slippage,
-  balancerBatchRouterAbi,
+  balancerBatchRouterAbiExtended,
   permit2Abi,
   vaultExtensionAbi_V3,
   vaultV3Abi,
@@ -39,7 +39,7 @@ export const useMultiSwap = () => {
 
     const batchRouterContract = getContract({
       address: batchRouterAddress,
-      abi: [...balancerBatchRouterAbi, ...vaultV3Abi, ...vaultExtensionAbi_V3, ...permit2Abi],
+      abi: [...balancerBatchRouterAbiExtended, ...vaultV3Abi, ...vaultExtensionAbi_V3, ...permit2Abi],
       client,
     });
 
@@ -86,7 +86,7 @@ export const useMultiSwap = () => {
 
     // 3. Encode swap function call for multicallData arg of Batch Router's permitBatchAndCall function
     const encodedSwapData = encodeFunctionData({
-      abi: balancerBatchRouterAbi,
+      abi: balancerBatchRouterAbiExtended,
       functionName: "swapExactIn",
       args: [pathsWithSlippage, deadline, wethIsEth, userData],
     });

--- a/packages/nextjs/hooks/v3/useMultiSwap.ts
+++ b/packages/nextjs/hooks/v3/useMultiSwap.ts
@@ -1,11 +1,11 @@
 import {
-  BALANCER_BATCH_ROUTER,
   MAX_UINT256,
   Slippage,
   balancerBatchRouterAbiExtended,
+  balancerV3Contracts,
   permit2Abi,
+  vaultAbi_V3,
   vaultExtensionAbi_V3,
-  vaultV3Abi,
 } from "@balancer/sdk";
 import { useMutation } from "@tanstack/react-query";
 import { encodeFunctionData, getContract, parseUnits, zeroAddress } from "viem";
@@ -35,11 +35,11 @@ export const useMultiSwap = () => {
     if (!walletClient) throw new Error("Wallet client missing");
 
     const client = { public: publicClient, wallet: walletClient };
-    const batchRouterAddress = BALANCER_BATCH_ROUTER[chainId];
+    const batchRouterAddress = balancerV3Contracts.BatchRouter[chainId as keyof typeof balancerV3Contracts.BatchRouter];
 
     const batchRouterContract = getContract({
       address: batchRouterAddress,
-      abi: [...balancerBatchRouterAbiExtended, ...vaultV3Abi, ...vaultExtensionAbi_V3, ...permit2Abi],
+      abi: [...balancerBatchRouterAbiExtended, ...vaultAbi_V3, ...vaultExtensionAbi_V3, ...permit2Abi],
       client,
     });
 

--- a/packages/nextjs/hooks/v3/useMultiSwapTxHash.ts
+++ b/packages/nextjs/hooks/v3/useMultiSwapTxHash.ts
@@ -1,4 +1,4 @@
-import { vaultV3Abi } from "@balancer/sdk";
+import { vaultAbi_V3 } from "@balancer/sdk";
 import { useSafeAppsSDK } from "@safe-global/safe-apps-react-sdk";
 import { useQuery } from "@tanstack/react-query";
 import { formatUnits, parseEventLogs } from "viem";
@@ -40,7 +40,7 @@ export function useMultiSwapTxHash() {
 
       if (txReceipt.status === "success") {
         const logs = parseEventLogs({
-          abi: vaultV3Abi,
+          abi: vaultAbi_V3,
           eventName: "Wrap",
           logs: txReceipt.logs,
         });

--- a/packages/nextjs/hooks/v3/useValidatePoolCreationInput.ts
+++ b/packages/nextjs/hooks/v3/useValidatePoolCreationInput.ts
@@ -1,4 +1,4 @@
-import { PoolType, TokenType } from "@balancer/sdk";
+import { PoolType, STABLE_POOL_CONSTRAINTS, TokenType } from "@balancer/sdk";
 import { isAddress, parseUnits } from "viem";
 import { useWalletClient } from "wagmi";
 import { useEclpParamValidations } from "~~/hooks/gyro";
@@ -74,7 +74,9 @@ export function useValidatePoolCreationInput() {
     !!swapFeePercentage && Number(swapFeePercentage) > 0 && Number(swapFeePercentage) <= 10,
     // Stable and StableSurge require valid amplification parameter
     (poolType !== PoolType.Stable && poolType !== PoolType.StableSurge) ||
-      (!!amplificationParameter && Number(amplificationParameter) >= 1 && Number(amplificationParameter) <= 5000),
+      (!!amplificationParameter &&
+        Number(amplificationParameter) >= STABLE_POOL_CONSTRAINTS.MIN_AMP &&
+        Number(amplificationParameter) <= STABLE_POOL_CONSTRAINTS.MAX_AMP),
     // GyroE type requires special validations for eclp params
     poolType !== PoolType.GyroE || (!baseParamsError && !derivedParamsError),
     isDelegatingSwapFeeManagement || isAddress(swapFeeManager),

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@balancer-labs/balancer-maths": "^0.0.25",
-    "@balancer/sdk": "^2.7.1",
+    "@balancer/sdk": "^3.0.0",
     "@heroicons/react": "^2.0.11",
     "@rainbow-me/rainbowkit": "2.1.2",
     "@safe-global/safe-apps-provider": "^0.18.5",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@balancer-labs/balancer-maths": "^0.0.25",
-    "@balancer/sdk": "^2.5.1",
+    "@balancer/sdk": "^2.7.1",
     "@heroicons/react": "^2.0.11",
     "@rainbow-me/rainbowkit": "2.1.2",
     "@safe-global/safe-apps-provider": "^0.18.5",

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -12,7 +12,7 @@ export type ScaffoldConfig = {
 
 const scaffoldConfig = {
   // The networks on which your DApp is live
-  targetNetworks: [chains.sepolia, chains.mainnet, chains.gnosis, chains.arbitrum, chains.base],
+  targetNetworks: [chains.sepolia, chains.mainnet, chains.gnosis, chains.arbitrum, chains.base, chains.avalanche],
 
   // If using chains.foundry as your targetNetwork, you must specify a network to fork
   targetFork: chains.sepolia,

--- a/packages/nextjs/utils/scaffold-eth/fetchPriceFromUniswap.ts
+++ b/packages/nextjs/utils/scaffold-eth/fetchPriceFromUniswap.ts
@@ -1,70 +1,11 @@
-import { ChainWithAttributes, getAlchemyHttpUrl } from "./networks";
-import { CurrencyAmount, Token } from "@uniswap/sdk-core";
-import { Pair, Route } from "@uniswap/v2-sdk";
-import { Address, createPublicClient, http, parseAbi } from "viem";
-import { mainnet } from "viem/chains";
-
-const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http(getAlchemyHttpUrl(mainnet.id)),
-});
-
-const ABI = parseAbi([
-  "function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)",
-  "function token0() external view returns (address)",
-  "function token1() external view returns (address)",
-]);
+import { ChainWithAttributes } from "./networks";
 
 export const fetchPriceFromUniswap = async (targetNetwork: ChainWithAttributes): Promise<number> => {
-  if (
-    targetNetwork.nativeCurrency.symbol !== "ETH" &&
-    targetNetwork.nativeCurrency.symbol !== "SEP" &&
-    !targetNetwork.nativeCurrencyTokenAddress
-  ) {
-    return 0;
-  }
   try {
-    const DAI = new Token(1, "0x6B175474E89094C44Da98b954EedeAC495271d0F", 18);
-    const TOKEN = new Token(
-      1,
-      targetNetwork.nativeCurrencyTokenAddress || "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-      18,
-    );
-    const pairAddress = Pair.getAddress(TOKEN, DAI) as Address;
-
-    const wagmiConfig = {
-      address: pairAddress,
-      abi: ABI,
-    };
-
-    const reserves = await publicClient.readContract({
-      ...wagmiConfig,
-      functionName: "getReserves",
-    });
-
-    const token0Address = await publicClient.readContract({
-      ...wagmiConfig,
-      functionName: "token0",
-    });
-
-    const token1Address = await publicClient.readContract({
-      ...wagmiConfig,
-      functionName: "token1",
-    });
-    const token0 = [TOKEN, DAI].find(token => token.address === token0Address) as Token;
-    const token1 = [TOKEN, DAI].find(token => token.address === token1Address) as Token;
-    const pair = new Pair(
-      CurrencyAmount.fromRawAmount(token0, reserves[0].toString()),
-      CurrencyAmount.fromRawAmount(token1, reserves[1].toString()),
-    );
-    const route = new Route([pair], TOKEN, DAI);
-    const price = parseFloat(route.midPrice.toSignificant(6));
-    return price;
+    return 0;
   } catch (error) {
-    console.error(
-      `useNativeCurrencyPrice - Error fetching ${targetNetwork.nativeCurrency.symbol} price from Uniswap: `,
-      error,
-    );
+    console.log("Error with targetNetwork", targetNetwork);
+    console.error(`useNativeCurrencyPrice - Error fetching price from Uniswap: `, error);
     return 0;
   }
 };

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -31,12 +31,15 @@ export const RPC_CHAIN_NAMES: Record<number, string> = {
   [chains.base.id]: "base-mainnet",
   [chains.baseGoerli.id]: "base-goerli",
   [chains.baseSepolia.id]: "base-sepolia",
+  [chains.avalanche.id]: "avax-mainnet",
 };
 
 export const INFURA_CHAIN_NAMES: Record<number, string> = {
   [chains.mainnet.id]: "mainnet",
   [chains.sepolia.id]: "sepolia",
   [chains.arbitrum.id]: "arbitrum-mainnet",
+  [chains.avalanche.id]: "avalanche-mainnet",
+  [chains.base.id]: "base-mainnet",
 };
 
 export const getAlchemyHttpUrl = (chainId: number) => {
@@ -57,6 +60,7 @@ export const RPC_FALLBACKS: Record<number, string> = {
   [chains.gnosis.id]: "https://gnosis.drpc.org",
   [chains.sepolia.id]: "https://sepolia.gateway.tenderly.co",
   [chains.base.id]: "https://base.llamarpc.com",
+  [chains.avalanche.id]: "https://avalanche.drpc.org",
 };
 
 export const getRpcFallbackUrl = (chainId: number) => {
@@ -104,6 +108,9 @@ export const NETWORKS_EXTRA_DATA: Record<string, ChainAttributes> = {
   },
   [chains.scrollSepolia.id]: {
     color: "#fbebd4",
+  },
+  [chains.avalanche.id]: {
+    color: "#92D9FA",
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,9 +300,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@balancer/sdk@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "@balancer/sdk@npm:2.5.1"
+"@balancer/sdk@npm:^2.7.1":
+  version: 2.7.1
+  resolution: "@balancer/sdk@npm:2.7.1"
   dependencies:
     "@balancer-labs/balancer-maths": 0.0.24
     "@types/big.js": ^6.2.2
@@ -310,7 +310,7 @@ __metadata:
     decimal.js-light: ^2.5.1
     lodash.clonedeep: ^4.5.0
     viem: ^2.22.3
-  checksum: 52402fa0ab34f77f0ac2d7ed08f228e9dccd7e50587bd3d0c44d5b33baa8ece8de5d5a621553725bf253bf5f0c81ae07d5f73bb78fe1b71e4cee52cd87c29e47
+  checksum: 98cef02dca8c9d294db96328bfe8be38ecc456e05f34f5a7c2865d74fd6183363ecf42d2e247e929595296a70d52ceb69298eb224e81134dd6720acba2342cf8
   languageName: node
   linkType: hard
 
@@ -1677,7 +1677,7 @@ __metadata:
   resolution: "@se-2/nextjs@workspace:packages/nextjs"
   dependencies:
     "@balancer-labs/balancer-maths": ^0.0.25
-    "@balancer/sdk": ^2.5.1
+    "@balancer/sdk": ^2.7.1
     "@heroicons/react": ^2.0.11
     "@rainbow-me/rainbowkit": 2.1.2
     "@safe-global/safe-apps-provider": ^0.18.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,9 +300,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@balancer/sdk@npm:^2.7.1":
-  version: 2.7.1
-  resolution: "@balancer/sdk@npm:2.7.1"
+"@balancer/sdk@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@balancer/sdk@npm:3.0.0"
   dependencies:
     "@balancer-labs/balancer-maths": 0.0.24
     "@types/big.js": ^6.2.2
@@ -310,7 +310,7 @@ __metadata:
     decimal.js-light: ^2.5.1
     lodash.clonedeep: ^4.5.0
     viem: ^2.22.3
-  checksum: 98cef02dca8c9d294db96328bfe8be38ecc456e05f34f5a7c2865d74fd6183363ecf42d2e247e929595296a70d52ceb69298eb224e81134dd6720acba2342cf8
+  checksum: fd78f5adef3e36ecf186085ec950f0f741149a447779225f26affeb607744a0bde3548df009ee903a9fcb8ac37702b83a63f785ebf15860563c759a56c3d9563
   languageName: node
   linkType: hard
 
@@ -1677,7 +1677,7 @@ __metadata:
   resolution: "@se-2/nextjs@workspace:packages/nextjs"
   dependencies:
     "@balancer-labs/balancer-maths": ^0.0.25
-    "@balancer/sdk": ^2.7.1
+    "@balancer/sdk": ^3.0.0
     "@heroicons/react": ^2.0.11
     "@rainbow-me/rainbowkit": 2.1.2
     "@safe-global/safe-apps-provider": ^0.18.5


### PR DESCRIPTION
Closes #50 

### Summary
- Updated to latest version of SDK `v3.0`
  - New stable pool raises amp limit from 5000 to 50000
  - New method of importing balancer addresses
- Restricted boosted suggestions to [only AAVE whitelist](https://github.com/balancer/metadata/blob/da53d6b2f9da31761f578b71b621b297f5d530ac/erc4626/index.json#L3)
- Removed unused fetches to uniswap for price ( scaffold-eth bloat )